### PR TITLE
updates ruby version targets for GH action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.7', '3.1']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Now targeting ruby 2.7 and 3.1.